### PR TITLE
Implement POSIX character class support

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -104,6 +104,15 @@ func compile(tree *ast.Node, sep []rune) (string, error) {
 		}
 		regex = fmt.Sprintf("[%v%v]", sign, meta(string(l.Chars)))
 
+	// POSIX classes like `[[:alpha:]]` are handled the same way by regexp
+	case ast.KindPOSIX:
+		p := tree.Value.(ast.POSIX)
+		sign := ""
+		if p.Not {
+			sign = "^"
+		}
+		regex = fmt.Sprintf("[%v[:%v:]]", sign, meta(string(p.Class)))
+
 	// stuff in a range e.g. `[a-d]` is handled the same way by regexp
 	case ast.KindRange:
 		r := tree.Value.(ast.Range)

--- a/glob_test.go
+++ b/glob_test.go
@@ -119,6 +119,11 @@ func TestGlob(t *testing.T) {
 
 		glob(true, "[a-z]", "c"),
 		glob(false, "[a-z]", "C"),
+		glob(true, "[[:alpha:]]", "C"),
+		glob(false, "[[:alpha:]]", "5"),
+		glob(true, "[[:^alpha:]]", "."),
+		glob(true, "[^[:alpha:]]", "."),
+		glob(true, "[[:space:]]", "\t"),
 		glob(true, "/{rate,[a-z][a-z][a-z]}*", "/rate"),
 		glob(true, "/{rate,[0-9][0-9][0-9]}*", "/rate"),
 		glob(true, "/{rate,[a-z][a-z][a-z]}*", "/usd"),
@@ -331,6 +336,21 @@ func BenchmarkAlternativesRegexpMismatch(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		_ = m.Match(f)
+	}
+}
+
+func BenchmarkAlternativesSuffixFirstGlobMatch(b *testing.B) {
+	m, _ := Compile(pattern_alternatives_suffix)
+
+	for i := 0; i < b.N; i++ {
+		_ = m.Match(fixture_alternatives_suffix_first_match)
+	}
+}
+func BenchmarkAlternativesSuffixFirstGlobMismatch(b *testing.B) {
+	m, _ := Compile(pattern_alternatives_suffix)
+
+	for i := 0; i < b.N; i++ {
+		_ = m.Match(fixture_alternatives_suffix_first_mismatch)
 	}
 }
 

--- a/syntax/ast/ast.go
+++ b/syntax/ast/ast.go
@@ -10,6 +10,11 @@ type List struct {
 	Chars string
 }
 
+type POSIX struct {
+	Not   bool
+	Class string
+}
+
 type Range struct {
 	Not    bool
 	Lo, Hi rune
@@ -29,6 +34,7 @@ const (
 	KindNothing Kind = iota
 	KindPattern
 	KindList
+	KindPOSIX
 	KindRange
 	KindCapture
 	KindText
@@ -91,6 +97,8 @@ func (k Kind) String() string {
 		return "Pattern"
 	case KindList:
 		return "List"
+	case KindPOSIX:
+		return "POSIX"
 	case KindRange:
 		return "Range"
 	case KindCapture:

--- a/syntax/lexer/lexer_test.go
+++ b/syntax/lexer/lexer_test.go
@@ -194,6 +194,34 @@ func TestLexGood(t *testing.T) {
 			},
 		},
 		{
+			pattern: "[[:alpha:]]",
+			items: []Token{
+				{RangeOpen, "["},
+				{Text, ":alpha:"},
+				{RangeClose, "]"},
+				{EOF, ""},
+			},
+		},
+		{
+			pattern: "[![:alpha:]]",
+			items: []Token{
+				{RangeOpen, "["},
+				{Not, "!"},
+				{Text, ":alpha:"},
+				{RangeClose, "]"},
+				{EOF, ""},
+			},
+		},
+		{
+			pattern: "[[:^alpha:]]",
+			items: []Token{
+				{RangeOpen, "["},
+				{Text, ":^alpha:"},
+				{RangeClose, "]"},
+				{EOF, ""},
+			},
+		},
+		{
 			pattern: "[!日-語]",
 			items: []Token{
 				{RangeOpen, "["},


### PR DESCRIPTION
From the bash manual:

> Within ‘[’ and ‘]’, character classes can be specified using the syntax [:class:], where class is one of the following classes defined in the POSIX standard:

```
alnum   alpha   ascii   blank   cntrl   digit   graph   lower
print   punct   space   upper   word    xdigit
```

> A character class matches any character belonging to that class. The word character class matches letters, digits, and the character ‘_’. 