### PR TITLE
Implement negation extglob patterns

### DIFF
--- a/extglob_test.go
+++ b/extglob_test.go
@@ -263,7 +263,7 @@ func TestExtGlob(t *testing.T) {
 			if result != test.should {
 				t.Errorf(
 					"pattern %q matching %q should be %v but got %v\n%s",
-					test.pattern, test.match, test.should, result, g.r,
+					test.pattern, test.match, test.should, result, g.p,
 				)
 			}
 		})
@@ -444,7 +444,7 @@ func TestNegationGlob(t *testing.T) {
 			if result != test.should {
 				t.Errorf(
 					"pattern %q matching %q should be %v but got %v\n%s",
-					test.pattern, test.match, test.should, result, g.r,
+					test.pattern, test.match, test.should, result, g.p,
 				)
 			}
 		})

--- a/glob_test.go
+++ b/glob_test.go
@@ -181,7 +181,7 @@ func TestGlob(t *testing.T) {
 			if result != test.should {
 				t.Errorf(
 					"pattern %q matching %q should be %v but got %v\n%s",
-					test.pattern, test.match, test.should, result, g.r,
+					test.pattern, test.match, test.should, result, g.p,
 				)
 			}
 		})

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,10 @@
 # Go Capture Globbing Library
 
-This library allows you to use capture groups in globs,
-by using the extended globbing functions (except for the `!` quantifier, which requires a non-regular expression).
+This library allows you to use capture groups in globs
+by using the extended globbing functions.
 
 This is implemented by compiling the glob patterns to regex,
-and then doing the matching and capturing with the Go regexp library.
+and then doing the matching and capturing with the Perl Compatible Regular Expression library.
 
 The parser, lexer, and general structure for this library are derived from the excellent https://github.com/gobwas/glob library.
 
@@ -101,8 +101,8 @@ func main() {
 This library is created for compile-once patterns. This means that the compilation could take time, but
 string matching is done faster, compared to the case when the template is compiled each time.
 
-Since it uses the Go regexp library to do the matching and capturing, it performs about on par with the
-regexp functions. If you need something faster, and don't need capture groups, we recommend https://github.com/gobwas/glob.
+Since it uses the PCRE library to do the matching and capturing, it performs about on par with regular expressions. 
+If you need something faster, and don't need capture groups, we recommend https://github.com/gobwas/glob.
 
 ## Syntax
 

--- a/syntax/syntax.go
+++ b/syntax/syntax.go
@@ -5,7 +5,7 @@ import (
 	"github.com/pachyderm/glob/syntax/lexer"
 )
 
-func Parse(s string) (*ast.Node, ast.CompilerToUse, error) {
+func Parse(s string) (*ast.Node, error) {
 	return ast.Parse(lexer.NewLexer(s))
 }
 


### PR DESCRIPTION
This implements https://github.com/pachyderm/pachyderm/issues/2911

Since regular expressions cannot implement negation extglobs, we have to use the PCRE library to process the equivalent "regular expression". However, we do not want to lose the benefits of using the regexp library when we can. Fortunately, it is easy to determine while parsing which compiler will be needed.

But even with PCRE, the way that negations work in glob is different from how they work in PCRE, so some finesse is required. I based the conversion on the one from micromatch/extglob: https://github.com/micromatch/extglob/blob/master/lib/compilers.js

Specifically, the scope of a negation is more aggressive, but there are also other glob subpatterns with higher precedence that thus limit its scope. In particular, this requires global information about the expression in order to determine the correct behavior. So in order to implement this, I used some invalid UTF-8 strings to act as dummy markers. One of these, the `boundaryDummy` is placed at any point where the scope of the negation expression would be superceded. The other, `closeNegDummy` is placed at the end of any subexpression that should be scoped as a negation.

Once the full expression has been generated, we look for the last `closeNegDummy` which is the only one that potentially needs to be altered. If there are any `boundaryDummy`s after it, then the PCRE `?!` has the same semantics, so we simply remove all the dummies. But if there are no `boundaryDummy`s following, that means we need to replace the `closeNegDummy`s with `$`, which tells it to match to the end of the line. 

In any case, we remove all the dummies before passing it to PCRE. 

All of this is done without imposing significant overhead.

I'm not fully confident that this procedure is exactly right, but it does pass the extensive tests from micromatch extglob: https://github.com/micromatch/extglob/blob/master/test/_negations.js, https://github.com/micromatch/extglob/blob/master/test/bash.js
It also passes some tests which micromatch extglob does not yet pass: https://github.com/micromatch/extglob/issues/10
There are a few points of disagreement, but after thinking carefully about them, I've decided that the behavior here is doing the more reasonable thing. 